### PR TITLE
Optimization

### DIFF
--- a/inc/app/camera.hpp
+++ b/inc/app/camera.hpp
@@ -15,9 +15,9 @@ class Camera {
     glm::vec3 screen_u_m{};
     glm::vec3 screen_v_m{};
     glm::vec3 screen_center_m{};
-    double lens_distance_m;
-    double width_m;
-    double aspect_ratio_m;
+    float lens_distance_m;
+    float width_m;
+    float aspect_ratio_m;
 
 public:
     Camera();
@@ -28,11 +28,11 @@ public:
 
     void setUp(const glm::vec3 &new_up);
 
-    void setLensDistance(const double &new_lens_distance);
+    void setLensDistance(const float new_lens_distance);
 
-    void setWidth(const double &new_width);
+    void setWidth(const float new_width);
 
-    void setAspectRatio(const double &new_aspect_ratio);
+    void setAspectRatio(const float new_aspect_ratio);
 
     [[nodiscard]] glm::vec3 getPosition() const;
 
@@ -48,9 +48,11 @@ public:
 
     [[nodiscard]] double getLensDistance() const;
 
-    [[nodiscard]] double getWidth() const;
+    [[nodiscard]] float getLensDistance() const;
 
-    bool createRay(double x, double y, Ray &camera_ray) const;
+    [[nodiscard]] float getWidth() const;
+
+    bool createRay(float x, float y, Ray &camera_ray) const;
 
     void updateCameraGeometry();
 };

--- a/inc/app/image.hpp
+++ b/inc/app/image.hpp
@@ -11,15 +11,8 @@
 #include <glm/glm.hpp>
 
 class Image {
-    std::vector<std::vector<double>> r_channel_m;
-    std::vector<std::vector<double>> g_channel_m;
-    std::vector<std::vector<double>> b_channel_m;
-    std::vector<std::vector<double>> a_channel_m;
     int width_m = 0;
     int height_m = 0;
-
-    double max_color_m = 0.0;
-    double min_exposure_m = 0.0;
 
     SDL_Renderer *renderer_m = nullptr;
     SDL_Texture *texture_m = nullptr;
@@ -27,11 +20,16 @@ class Image {
 public:
     ~Image();
 
+    Image() = default;
+
+    Image(const Image &) = delete;
+
+    Image &operator=(const Image &) = delete;
+
+    Uint32 *pixels_m = nullptr;
+    glm::vec3 bg_color_m{};
+
     void initialize(int width, int height, SDL_Renderer *renderer);
-
-    void setPixel(int x, int y, double r, double g, double b, double a);
-
-    [[nodiscard]] glm::vec4 getPixel(int x, int y) const;
 
     void display();
 
@@ -39,11 +37,11 @@ public:
 
     [[nodiscard]] int getHeight() const;
 
-    [[nodiscard]] Uint32 convertColor(double r, double g, double b, double a) const;
+    void setPixel(int x, int y, glm::vec3 color) const;
+
+    [[nodiscard]] static Uint32 convertColor(float r, float g, float b);
 
     void initTexture();
-
-    void computeMaxValues();
 };
 
 #endif //RAY_TRACER_IMAGE_HPP

--- a/inc/lights/light_source.hpp
+++ b/inc/lights/light_source.hpp
@@ -12,7 +12,7 @@ class LightSource {
 protected:
     glm::vec3 position_m = glm::vec3(0.0f, 0.0f, 0.0f);
     glm::vec3 color_m = glm::vec3(1.0f, 1.0f, 1.0f);
-    double intensity_m = 1.0f;
+    float intensity_m = 1.0f;
 
 public:
     void setPosition(const glm::vec3 &position);
@@ -21,7 +21,7 @@ public:
 
     [[nodiscard]] glm::vec3 getColor() const;
 
-    void setIntensity(double intensity);
+    void setIntensity(float intensity);
 };
 
 #endif //RAY_TRACER_LIGHT_SOURCE_HPP

--- a/inc/lights/point_light.hpp
+++ b/inc/lights/point_light.hpp
@@ -18,7 +18,7 @@ public:
     bool computeDiffIllum(const glm::vec3 &int_point, const glm::vec3 &loc_normal,
                           const std::vector<std::shared_ptr<Object>> &object_list,
                           const std::shared_ptr<Object> &current_object,
-                          glm::vec3 &color, double &intensity) const;
+                          glm::vec3 &color, float &intensity) const;
 
     [[nodiscard]] glm::vec3
     computeSpecIllum(const Ray &camera_ray, const std::vector<std::shared_ptr<Object>> &object_list,

--- a/inc/ray.hpp
+++ b/inc/ray.hpp
@@ -20,7 +20,7 @@ public:
 
     [[nodiscard]] glm::vec3 getDirection() const;
 
-    [[nodiscard]] glm::vec3 getPoint(double t) const;
+    [[nodiscard]] glm::vec3 getPoint(float t) const;
 
     static Ray getRayFromPoints(const glm::vec3 &origin, const glm::vec3 &destination);
 };

--- a/src/app/camera.cpp
+++ b/src/app/camera.cpp
@@ -25,15 +25,15 @@ void Camera::setUp(const glm::vec3 &new_up) {
     screen_up_m = glm::normalize(new_up);
 }
 
-void Camera::setLensDistance(const double &new_lens_distance) {
+void Camera::setLensDistance(const float new_lens_distance) {
     lens_distance_m = new_lens_distance;
 }
 
-void Camera::setWidth(const double &new_width) {
+void Camera::setWidth(const float new_width) {
     width_m = new_width;
 }
 
-void Camera::setAspectRatio(const double &new_aspect_ratio) {
+void Camera::setAspectRatio(const float new_aspect_ratio) {
     aspect_ratio_m = new_aspect_ratio;
 }
 
@@ -49,11 +49,11 @@ glm::vec3 Camera::getUp() const {
     return screen_up_m;
 }
 
-double Camera::getLensDistance() const {
+float Camera::getLensDistance() const {
     return lens_distance_m;
 }
 
-double Camera::getWidth() const {
+float Camera::getWidth() const {
     return width_m;
 }
 
@@ -77,7 +77,7 @@ void Camera::updateCameraGeometry() {
     screen_v_m *= static_cast<float>(width_m / aspect_ratio_m);
 }
 
-bool Camera::createRay(double x, double y, Ray &camera_ray) const {
+bool Camera::createRay(float x, float y, Ray &camera_ray) const {
     glm::vec3 point_on_screen =
             screen_center_m + screen_u_m * static_cast<float>(x) + screen_v_m * static_cast<float>(y);
     camera_ray = Ray::getRayFromPoints(position_m, point_on_screen);

--- a/src/app/image.cpp
+++ b/src/app/image.cpp
@@ -9,62 +9,27 @@ Image::~Image() {
     if (texture_m != nullptr) {
         SDL_DestroyTexture(texture_m);
     }
+
+    delete[] pixels_m;
 }
 
 void Image::initialize(int width, int height, SDL_Renderer *renderer) {
-    r_channel_m.resize(width, std::vector<double>(height, 0.0));
-    g_channel_m.resize(width, std::vector<double>(height, 0.0));
-    b_channel_m.resize(width, std::vector<double>(height, 0.0));
-    a_channel_m.resize(width, std::vector<double>(height, 0.0));
-
     width_m = width;
     height_m = height;
     renderer_m = renderer;
 
-    min_exposure_m = 1.0;
+    bg_color_m = glm::vec3(0.0, 0.0, 0.0);
+
+    pixels_m = new Uint32[width_m * height_m];
 
     initTexture();
 }
 
-void Image::setPixel(int x, int y, double r, double g, double b, double a) {
-    r_channel_m[x][y] = r;
-    g_channel_m[x][y] = g;
-    b_channel_m[x][y] = b;
-    a_channel_m[x][y] = a;
-}
-
-glm::vec4 Image::getPixel(int x, int y) const {
-    return {r_channel_m[x][y], g_channel_m[x][y], b_channel_m[x][y], a_channel_m[x][y]};
-}
-
 void Image::display() {
-    computeMaxValues();
-    auto *temp_pixels = new Uint32[width_m * height_m];
-
-    memset(temp_pixels, 0, width_m * height_m * sizeof(Uint32));
-
-    for (int y = 0; y < height_m; y++) {
-        for (int x = 0; x < width_m; x++) {
-            temp_pixels[y * width_m + x] = convertColor(r_channel_m[x][y],
-                                                        g_channel_m[x][y],
-                                                        b_channel_m[x][y],
-                                                        a_channel_m[x][y]);
-        }
-    }
-
     auto uint32_size = static_cast<int>(sizeof(Uint32));
-    SDL_UpdateTexture(texture_m, nullptr, temp_pixels, width_m * uint32_size);
+    SDL_UpdateTexture(texture_m, nullptr, pixels_m, width_m * uint32_size);
 
-    delete[] temp_pixels;
-
-    SDL_Rect src_rect;
-    SDL_Rect bounds;
-    src_rect.x = 0;
-    src_rect.y = 0;
-    src_rect.w = width_m;
-    src_rect.h = height_m;
-    bounds = src_rect;
-    SDL_RenderCopy(renderer_m, texture_m, &src_rect, &bounds);
+    SDL_RenderCopy(renderer_m, texture_m, nullptr, nullptr);
 }
 
 void Image::initTexture() {
@@ -92,16 +57,25 @@ void Image::initTexture() {
     SDL_FreeSurface(temp_surface);
 }
 
-Uint32 Image::convertColor(double r, double g, double b, double a) const {
-    auto red = static_cast<Uint32>(255 * r / max_color_m);
-    auto blue = static_cast<Uint32>(255 * b / max_color_m);
-    auto green = static_cast<Uint32>(255 * g / max_color_m);
-    auto alpha = static_cast<Uint32>(255 * a / max_color_m);
+void Image::setPixel(int x, int y, glm::vec3 color) const {
+    auto index = y * width_m + x;
+    pixels_m[index] = convertColor(color.r, color.g, color.b);
+}
+
+Uint32 Image::convertColor(float r, float g, float b) {
+    if (r > 1.0) r = 1.0;
+    if (g > 1.0) g = 1.0;
+    if (b > 1.0) b = 1.0;
+
+    auto red = static_cast<Uint8>(255 * r);
+    auto blue = static_cast<Uint8>(255 * b);
+    auto green = static_cast<Uint8>(255 * g);
+    auto alpha = 0xFF000000;
 
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
     return red << 24 | (green << 16) | (blue << 8) | alpha;
 #else
-    return alpha << 24 | (blue << 16) | (green << 8) | red;
+    return alpha | (blue << 16) | (green << 8) | red;
 #endif
 }
 
@@ -111,24 +85,4 @@ int Image::getWidth() const {
 
 int Image::getHeight() const {
     return height_m;
-}
-
-void Image::computeMaxValues() {
-    double max_red = 0.0;
-    double max_green = 0.0;
-    double max_blue = 0.0;
-    for (int x = 0; x < width_m; x++) {
-        for (int y = 0; y < height_m; y++) {
-            max_red = std::max(max_red, r_channel_m[x][y]);
-            max_green = std::max(max_green, g_channel_m[x][y]);
-            max_blue = std::max(max_blue, b_channel_m[x][y]);
-        }
-    }
-
-    double max_color = std::max({max_red, max_green, max_blue});
-
-    if (max_color < min_exposure_m) {
-        return;
-    }
-    max_color_m = max_color;
 }

--- a/src/app/scene.cpp
+++ b/src/app/scene.cpp
@@ -48,10 +48,10 @@ void Scene::render(Image &output_image) {
                                   Ray camera_ray;
                                   glm::vec3 int_point;
                                   glm::vec3 loc_normal;
-                                  double x_factor = 1.0 / (static_cast<double>(width) / 2.0);
-                                  double y_factor = 1.0 / (static_cast<double>(height) / 2.0);
-                                  double norm_x = static_cast<double>(x) * x_factor - 1.0;
-                                  double norm_y = static_cast<double>(y) * y_factor - 1.0;
+                                  float x_factor = 2 / (static_cast<float>(width));
+                                  float y_factor = 2 / (static_cast<float>(height));
+                                  float norm_x = static_cast<float>(x) * x_factor - 1;
+                                  float norm_y = static_cast<float>(y) * y_factor - 1;
                                   camera_m.createRay(norm_x, norm_y, camera_ray);
                                   internalRender(x, y, camera_ray, output_image, int_point, loc_normal);
                               }
@@ -66,7 +66,7 @@ void Scene::internalRender(int x, int y, const Ray &camera_ray, Image &output_im
     std::shared_ptr<Object> closest_object;
     glm::vec3 closest_int_point;
     glm::vec3 closest_loc_normal;
-    double min_distance = std::numeric_limits<double>::max();
+    float min_distance = std::numeric_limits<float>::max();
 
     for (const auto &object_m: object_list_m) {
         bool valid_intersection = object_m->testIntersections(camera_ray,
@@ -74,7 +74,7 @@ void Scene::internalRender(int x, int y, const Ray &camera_ray, Image &output_im
                                                               loc_normal);
         if (valid_intersection) {
             blank = false;
-            double distance = glm::length(camera_ray.getOrigin() - int_point);
+            float distance = glm::length(camera_ray.getOrigin() - int_point);
             if (distance < min_distance) {
                 min_distance = distance;
                 closest_object = object_m;
@@ -96,11 +96,10 @@ void Scene::internalRender(int x, int y, const Ray &camera_ray, Image &output_im
     }
 }
 
-glm::vec3
-Scene::computeColor(const Ray &camera_ray, const std::shared_ptr<Object> &current_object, const glm::vec3 &int_point,
-                    const glm::vec3 &loc_normal) const {
+glm::vec3 Scene::computeColor(const Ray &camera_ray, const std::shared_ptr<Object> &current_object,
+                              const glm::vec3 &int_point, const glm::vec3 &loc_normal) const {
     float ambient_intensity = 0.05f;
-    double intensity{};
+    float intensity{};
     glm::vec3 color{};
     glm::vec3 output_color{};
     glm::vec3 ambient_color{};
@@ -118,7 +117,7 @@ Scene::computeColor(const Ray &camera_ray, const std::shared_ptr<Object> &curren
 
         if (valid_illumination) {
             illuminated = true;
-            diffuse_color += color * static_cast<float>(intensity);
+            diffuse_color += color * intensity;
         }
     }
 

--- a/src/app/scene.cpp
+++ b/src/app/scene.cpp
@@ -19,76 +19,19 @@ Scene::Scene() {
     light_list_m.emplace_back(std::make_shared<PointLight>());
     light_list_m[0]->setPosition(glm::vec3(-0.0f, -10.0f, 25.0f));
     light_list_m[0]->setColor(glm::vec3(1.0f, 1.0f, 1.0f));
-    light_list_m.emplace_back(std::make_shared<PointLight>());
-    light_list_m[1]->setPosition(glm::vec3(25.0f, -10.0f, 25.0f));
-    light_list_m[1]->setColor(glm::vec3(1.0f, 1.0f, 0.8f));
 
     object_list_m.emplace_back(std::make_shared<Sphere>());
-    Transformation transformation1;
-    transformation1.setTransform(glm::vec3(-1.5f, 0.0f, 0.0f),
+    Transformation transformation5;
+    transformation5.setTransform(glm::vec3(0.0f, 0.0f, 0.0f),
                                  glm::vec3(0.0f, 0.0f, 0.0f),
-                                 glm::vec3(0.5f, 0.5f, 0.75f));
+                                 glm::vec3(1.0f, 1.0f, 1.0f));
+    object_list_m[0]->setTransformation(transformation5);
     Material material1;
-    material1.setupMaterial(glm::vec3(0.0f, 1.0f, 0.0f),
-                            glm::vec3(0.0f, 1.0f, 0.0f),
+    material1.setupMaterial(glm::vec3(0.8f, 0.2f, 0.3f),
+                            glm::vec3(0.4f, 0.5f, 0.9f),
                             glm::vec3(1.0f, 1.0f, 1.0f),
-                            32.0f);
+                            128.0f);
     object_list_m[0]->setMaterial(material1);
-    object_list_m[0]->setTransformation(transformation1);
-
-    object_list_m.emplace_back(std::make_shared<Plane>());
-    Transformation transplane;
-    transplane.setTransform(glm::vec3(0.0f, 0.0f, -1.0f),
-                            glm::vec3(0.0f, 0.0f, 0.0f),
-                            glm::vec3(5.0f, 5.0f, 1.0f));
-
-    Material material2;
-    material2.setupMaterial(glm::vec3(0.0f, 0.0f, 1.0f),
-                            glm::vec3(0.0f, 0.0f, 1.0f),
-                            glm::vec3(0.0f, 0.0f, 1.0f),
-                            32.0f);
-    object_list_m[1]->setTransformation(transplane);
-    object_list_m[1]->setMaterial(material2);
-//    object_list_m[1]->setColor(glm::vec3(1.0f, 0.0f, 0.0f));
-
-//    Transformation transformation2;
-//    transformation2.setTransform(glm::vec3(0.0f, 0.0f, 0.0f),
-//                                 glm::vec3(0.0f, 0.0f, 0.0f),
-//                                 glm::vec3(0.75f, 0.5f, 0.5f));
-//    Transformation transformation3;
-//    transformation3.setTransform(glm::vec3(1.5f, 0.0f, 0.0f),
-//                                 glm::vec3(0.0f, 0.0f, 0.0f),
-//                                 glm::vec3(0.75f, 0.75f, 0.75f));
-//
-//    object_list_m[1]->setTransformation(transformation2);
-//    object_list_m[2]->setTransformation(transformation3);
-//
-//    object_list_m[0]->setColor(glm::vec3(0.0f, 1.0f, 0.0f));
-//    object_list_m[1]->setColor(glm::vec3(1.0f, 0.0f, 0.0f));
-//    object_list_m[2]->setColor(glm::vec3(0.0f, 0.0f, 1.0f));
-//
-//    object_list_m.emplace_back(std::make_shared<Plane>());
-//    Transformation transformation4;
-//    transformation4.setTransform(glm::vec3(0.0f, 1.0f, -1.0f),
-//                                 glm::vec3(0.1f, 0.0f, 0.0f),
-//                                 glm::vec3(5.0f, 5.0f, 1.0f));
-//    object_list_m[3]->setTransformation(transformation4);
-//    object_list_m[3]->setColor(glm::vec3(1.0f, 0.0f, 0.0f));
-
-//    object_list_m.emplace_back(std::make_shared<TriangleMesh>("../models/suzanne.obj"));
-    object_list_m.emplace_back(std::make_shared<TriangleMesh>("../models/cube.obj"));
-
-    Transformation dda1;
-    dda1.setTransform(glm::vec3(4.0f, 0.0f, 2.0f),
-                      glm::vec3(glm::half_pi<float>(), 0.0f, 0.0f),
-                      glm::vec3(2.0f, 2.0f, 2.0f));
-    object_list_m[2]->setTransformation(dda1);
-    Material material3;
-    material3.setupMaterial(glm::vec3(0.8f, 0.2f, 0.3f),
-                            glm::vec3(1.0f, 0.5f, 0.5f),
-                            glm::vec3(1.0f, 1.0f, 1.0f),
-                            256.0f);
-    object_list_m[2]->setMaterial(material3);
 }
 
 void Scene::render(Image &output_image) {

--- a/src/app/scene.cpp
+++ b/src/app/scene.cpp
@@ -146,9 +146,10 @@ void Scene::internalRender(int x, int y, const Ray &camera_ray, Image &output_im
                                               closest_object,
                                               closest_int_point,
                                               closest_loc_normal);
-        output_image.setPixel(x, y, output_color.r, output_color.g, output_color.b, 1.0);
+
+        output_image.setPixel(x, y, output_color);
     } else {
-        output_image.setPixel(x, y, 0.2, 0.2, 0.2, 1.0);
+        output_image.setPixel(x, y, output_image.bg_color_m);
     }
 }
 

--- a/src/lights/light_source.cpp
+++ b/src/lights/light_source.cpp
@@ -12,7 +12,7 @@ void LightSource::setColor(const glm::vec3 &color) {
     color_m = color;
 }
 
-void LightSource::setIntensity(double intensity) {
+void LightSource::setIntensity(float intensity) {
     intensity_m = intensity;
 }
 

--- a/src/lights/point_light.cpp
+++ b/src/lights/point_light.cpp
@@ -13,7 +13,7 @@ PointLight::PointLight() : LightSource() {
 bool PointLight::computeDiffIllum(const glm::vec3 &int_point, const glm::vec3 &loc_normal,
                                   const std::vector<std::shared_ptr<Object>> &object_list,
                                   const std::shared_ptr<Object> &current_object, glm::vec3 &color,
-                                  double &intensity) const {
+                                  float &intensity) const {
 
     Ray light_ray(int_point, position_m - int_point);
     glm::vec3 between_int_point;
@@ -29,14 +29,14 @@ bool PointLight::computeDiffIllum(const glm::vec3 &int_point, const glm::vec3 &l
         }
     }
 
-    double angle = glm::acos(glm::dot(loc_normal, light_ray.getDirection()));
+    float angle = glm::acos(glm::dot(loc_normal, light_ray.getDirection()));
     if (angle > glm::half_pi<decltype(angle)>()) {
         color = color_m;
         intensity = 0.0;
         return false;
     } else {
         color = color_m;
-        intensity = intensity_m * (1.0 - (angle / glm::half_pi<decltype(angle)>()));
+        intensity = intensity_m * static_cast<float>(1.0 - (angle / glm::half_pi<decltype(angle)>()));
         return true;
     }
 }

--- a/src/objects/plane.cpp
+++ b/src/objects/plane.cpp
@@ -4,7 +4,7 @@
 
 #include "objects/plane.hpp"
 
-constexpr double kEpsilon = 0.0001f;
+constexpr float kEpsilon = 0.0001f;
 
 bool
 Plane::testIntersections(const Ray &cast_ray, glm::vec3 &int_point, glm::vec3 &loc_normal) const {
@@ -15,7 +15,7 @@ Plane::testIntersections(const Ray &cast_ray, glm::vec3 &int_point, glm::vec3 &l
         return false;
     }
 
-    double t = -local_ray.getOrigin().z / k.z;
+    float t = -local_ray.getOrigin().z / k.z;
     if (t < 0.0) {
         return false;
     }

--- a/src/objects/sphere.cpp
+++ b/src/objects/sphere.cpp
@@ -8,9 +8,9 @@
 bool Sphere::testIntersections(const Ray &cast_ray, glm::vec3 &int_point, glm::vec3 &loc_normal) const {
     Ray local_ray = transformation_m.applyTransform(cast_ray, Direction::BACKWARD);
 
-    double b = 2.0 * glm::dot(local_ray.getOrigin(), local_ray.getDirection());
-    double c = glm::dot(local_ray.getOrigin(), local_ray.getOrigin()) - 1.0f;
-    double discriminant = b * b - 4.0 * c;
+    float b = 2.0 * glm::dot(local_ray.getOrigin(), local_ray.getDirection());
+    float c = glm::dot(local_ray.getOrigin(), local_ray.getOrigin()) - 1.0f;
+    float discriminant = b * b - 4.0 * c;
 
     glm::vec3 loc_int_point;
 
@@ -18,9 +18,9 @@ bool Sphere::testIntersections(const Ray &cast_ray, glm::vec3 &int_point, glm::v
         return false;
     }
 
-    double num_sqrt = sqrt(discriminant);
-    double t1 = (-b + num_sqrt) / 2.0;
-    double t2 = (-b - num_sqrt) / 2.0;
+    float num_sqrt = sqrt(discriminant);
+    float t1 = (-b + num_sqrt) / 2.0;
+    float t2 = (-b - num_sqrt) / 2.0;
 
     if ((t1 < 0.0) || (t2 < 0.0)) {
         return false;

--- a/src/objects/triangle.cpp
+++ b/src/objects/triangle.cpp
@@ -14,7 +14,7 @@ Triangle::Triangle(const Vertex &v1, const Vertex &v2, const Vertex &v3) {
 }
 
 bool Triangle::testIntersections(const Ray &cast_ray, glm::vec3 &int_point, glm::vec3 &loc_normal) const {
-    constexpr double kEpsilon = 0.0001;
+    constexpr float kEpsilon = 0.0001;
 
     glm::vec3 p_vec = glm::cross(cast_ray.getDirection(), e2_m);
     float determinant = glm::dot(e1_m, p_vec);

--- a/src/ray.cpp
+++ b/src/ray.cpp
@@ -18,8 +18,8 @@ glm::vec3 Ray::getDirection() const {
     return direction_m;
 }
 
-glm::vec3 Ray::getPoint(double t) const {
-    return origin_m + direction_m * static_cast<float>(t);
+glm::vec3 Ray::getPoint(float t) const {
+    return origin_m + direction_m * t;
 }
 
 Ray Ray::getRayFromPoints(const glm::vec3 &origin, const glm::vec3 &destination) {


### PR DESCRIPTION
This pull request brings some optimizations. The main one is the **rejection** of individual attributes of the image class for the matrices of each of the color channels. Now the `internal_render` function directly writes values ​​to a color array that is passed directly to `SDL`. This array is now allocated only **once** when the image class object is initialized and deallocated in the destructor.

In addition to these changes, minor optimizations were also made, using `float` instead of `double` throughout the project, which also helped to unify the types used